### PR TITLE
improvement: Add support for creating fargate profiles with different subnets.

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -100,6 +100,9 @@ module "eks" {
       #   GithubOrg   = "terraform-aws-modules"
       # }
 
+      # using specific subnets instead of all the ones configured in eks
+      # subnets = ["subnet-0ca3e3d1234a56c78"]
+
       tags = {
         Owner = "test"
       }

--- a/modules/fargate/fargate.tf
+++ b/modules/fargate/fargate.tf
@@ -17,7 +17,7 @@ resource "aws_eks_fargate_profile" "this" {
   cluster_name           = var.cluster_name
   fargate_profile_name   = lookup(each.value, "name", format("%s-fargate-%s", var.cluster_name, replace(each.key, "_", "-")))
   pod_execution_role_arn = local.pod_execution_role_arn
-  subnet_ids             = each.value.subnets
+  subnet_ids             = lookup(each.value, "subnets", var.subnets)
   tags                   = each.value.tags
 
   selector {

--- a/modules/fargate/locals.tf
+++ b/modules/fargate/locals.tf
@@ -5,7 +5,6 @@ locals {
 
   fargate_profiles_expanded = { for k, v in var.fargate_profiles : k => merge(
     {
-      subnets = var.subnets,
       tags    = var.tags,
     },
     v,


### PR DESCRIPTION
# PR o'clock

## Description

This patch add support for creating different fargate profiles
each with its own subnet list. The default behavior is to
behave has before creating all fargate profiles with all
the private subnets configured in eks.


### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
